### PR TITLE
Add full url input

### DIFF
--- a/nodes/cai_download.py
+++ b/nodes/cai_download.py
@@ -8,12 +8,13 @@ class CivitAIDownloader:
     def INPUT_TYPES(cls):
         return {
             "required": {       
-                "model_id":  ("STRING", {"multiline": False, "default": "360292"}),
-                "token_id": ("STRING", {"multiline": False, "default": "token_here"}),
                 "save_dir": (get_model_dirs(),),
             },
             "optional" : {
-                "ignore": ("BOOLEAN", { "default": False})
+                "ignore": ("BOOLEAN", { "default": False}),
+                "model_id":  ("STRING", {"multiline": False, "default": "360292"}),
+                "token_id": ("STRING", {"multiline": False, "default": ""}),
+                "full_url": ("STRING", {"multiline": False, "default": ""})
             }
         }
         
@@ -24,13 +25,14 @@ class CivitAIDownloader:
     CATEGORY     = "loaders"
 
     # inputs match input types
-    def download(self, model_id, token_id, save_dir, ignore):  
+    def download(self, model_id, token_id, save_dir, ignore, full_url):  
         print("Dowloading")
         print(f"\tModel: {model_id}")
         print(f"\tToken: {token_id}")
+        print(f"\tFull URL: {full_url}")
         print(f"\tSaving to: {save_dir}")
         
         # https://civitai.com/models/321320/wildcardx-xl-lightning
         if(not ignore):
-            download_cai(model_id, token_id, save_dir)
+            download_cai(model_id, token_id, save_dir, full_url)
         return {}

--- a/nodes/cai_utils.py
+++ b/nodes/cai_utils.py
@@ -37,7 +37,7 @@ def download_file_with_token(url, params=None, save_path='.'):
         print(f'An error occurred: {err}')
 
             
-def download_cai(MODEL_ID, TOKEN, LOCAL_PATH):
+def download_cai(MODEL_ID, TOKEN, LOCAL_PATH, FULL_URL):
     # Directory path where the file will be saved
     directory_path = os.path.join(get_base_dir(), LOCAL_PATH)
 
@@ -46,8 +46,14 @@ def download_cai(MODEL_ID, TOKEN, LOCAL_PATH):
         os.makedirs(directory_path, exist_ok=True)
 
     # URL and parameters for the request
-    url = f'https://civitai.com/api/download/models/{MODEL_ID}'
-    params = {'token': TOKEN}
+    if not FULL_URL and not MODEL_ID:
+        print("Should have at least full_url or model_id for model download.")
+    
+    if FULL_URL:
+        url = f'{FULL_URL}'
+    else:
+        url = f'https://civitai.com/api/download/models/{MODEL_ID}'
+    params = {'token': TOKEN} if TOKEN else {}
 
     # Call the download function without checking for file existence
     download_success = download_file_with_token(url, params, directory_path)

--- a/nodes/cai_utils.py
+++ b/nodes/cai_utils.py
@@ -10,6 +10,7 @@ def download_file_with_token(url, params=None, save_path='.'):
         # Send a GET request to the URL
         with requests.get(url, params=params, stream=True) as response:
             response.raise_for_status()  # Raise an error for bad responses
+            print(f"Downloading model successfully from {response.url}")
 
             # Get filename from the content-disposition header if available
             cd = response.headers.get('content-disposition')
@@ -30,6 +31,7 @@ def download_file_with_token(url, params=None, save_path='.'):
                     file.write(chunk)
             
             print(f"File downloaded successfully: {file_path}")
+            return True
 
     except HTTPError as http_err:
         print(f'HTTP error occurred: {http_err}')
@@ -53,7 +55,7 @@ def download_cai(MODEL_ID, TOKEN, LOCAL_PATH, FULL_URL):
         url = f'{FULL_URL}'
     else:
         url = f'https://civitai.com/api/download/models/{MODEL_ID}'
-    params = {'token': TOKEN} if TOKEN else {}
+    params = {'token': TOKEN } if TOKEN else {}
 
     # Call the download function without checking for file existence
     download_success = download_file_with_token(url, params, directory_path)


### PR DESCRIPTION
Add `full_url` input for downloading civitai models, by copy the download path directly to the field instead of guessing the parameters.