### PR TITLE
fix: Use relative WEB_DIRECTORY path for current ComfyUI compatibility

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,27 +1,25 @@
-from .nodes.hf.hf_download import HFDownloader
 from .nodes.auto.downloader import AutoModelDownloader
 from .nodes.cai.cai_download import CivitAIDownloader
-import os
+from .nodes.hf.hf_download import HFDownloader
 
-# Node mappings
-NODE_CLASS_MAPPINGS = { 
+NODE_CLASS_MAPPINGS = {
     "HF Downloader": HFDownloader,
     "Auto Model Downloader": AutoModelDownloader,
     "CivitAI Downloader": CivitAIDownloader,
 }
 
-# Display names
-NODE_DISPLAY_NAME_MAPPINGS = { 
+NODE_DISPLAY_NAME_MAPPINGS = {
     "HF Downloader": "HF Download",
     "Auto Model Downloader": "Auto Model Finder (Experimental)",
     "CivitAI Downloader": "CivitAI Download",
 }
 
-# Web directory for JavaScript files
-WEB_DIRECTORY = os.path.join(os.path.dirname(os.path.realpath(__file__)), "js")
+# Relative path required by ComfyUI's frontend extension loader.
+# See: https://docs.comfy.org/custom-nodes/js/javascript_overview
+WEB_DIRECTORY = "./js"
 
 __all__ = [
     "NODE_CLASS_MAPPINGS",
     "NODE_DISPLAY_NAME_MAPPINGS",
-    "WEB_DIRECTORY"
+    "WEB_DIRECTORY",
 ]


### PR DESCRIPTION
## Problem

`WEB_DIRECTORY` is set to an absolute path via `os.path.join(os.path.dirname(os.path.realpath(__file__)), "js")`. Current versions of ComfyUI resolve `WEB_DIRECTORY` *relative to the custom node directory*, so passing an absolute path results in a double-joined path like:

```
/path/to/custom_nodes/comfyui-model-downloader/home/user/.../comfyui-model-downloader/js
```

This causes the JS frontend extensions to fail to load. Without the JS, download requests that should be intercepted by the frontend fall through to the browser as raw file downloads.

## Fix

Replace the absolute path construction with the relative `"./js"` format per the [official ComfyUI docs](https://docs.comfy.org/custom-nodes/js/javascript_overview):

```python
# Before
WEB_DIRECTORY = os.path.join(os.path.dirname(os.path.realpath(__file__)), "js")

# After
WEB_DIRECTORY = "./js"
```

## Additional cleanup

- Remove unused `import os`
- Sort imports alphabetically
- Remove trailing whitespace in dict literals
- Add trailing comma in `__all__` list
- Add trailing newline (POSIX compliance)

## Testing

Verified on a live ComfyUI instance (latest main branch) — HF Downloader, CivitAI Downloader, and Auto Model Finder all load and function correctly after this change.